### PR TITLE
Resolve #1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN : &&\
     rm /tmp/m2-repository.tar.bz2 &&\
     apk update &&\
     apk add --no-progress --virtual /build openssl-dev libxml2-dev libxslt-dev libffi-dev ruby-dev make python3-dev cargo &&\
-    apk add --no-progress git-lfs gcc g++ musl-dev libxml2 libxslt git ruby ruby-etc ruby-json ruby-multi_json ruby-io-console ruby-bigdecimal openssh-client maven openjdk8 gnupg &&\
+    apk add --no-progress git-lfs gcc g++ musl-dev libxml2 libxslt git ruby ruby-etc ruby-json ruby-multi_json ruby-io-console ruby-bigdecimal openssh-client maven openjdk11 gnupg &&\
     pip install --upgrade \
         pip setuptools wheel \
         github3.py==${github3_py} \
@@ -57,14 +57,7 @@ RUN : &&\
         sphinx==${sphinx} \
         twine==${twine} \
         &&\
-    cd /usr/src &&\
-    git clone https://github.com/github-changelog-generator/github-changelog-generator.git &&\
-    cd github-changelog-generator &&\
-    git checkout ${github_changelog_commit} &&\
-    gem build github_changelog_generator.gemspec &&\
-    gem install github_changelog_generator-1.15.2.gem --source https://rubygems.org &&\
-    cd .. &&\
-    rm -r github-changelog-generator &&\
+    gem install github_changelog_generator --version 1.15.2 &&\
     apk del /build &&\
     rm -rf /var/cache/apk/* &&\
     : /

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ docker image push nasapds/pds-github-actions-base:latest
 - 💀 There isn't even [anonymous pulls of images from GitHub Packages](https://github.community/t/make-it-possible-to-pull-docker-images-anonymously-from-github-package-registry/16677)!
 - 😑 Apparently engineers at GitHub are recommending to [migrate from GitHub Packages to the new GitHub Container Registry](https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images). The Container Registry is currently in public β.
 - 💽 It's currently ~~213~~ ~~216~~ ~~579~~ ~~593~~ ~~790~~ ~~815~~ ~~669~~ 931
- MiB. ~~Let's try and keep it around there 😲 (Thanks, Java. And C++. But mostly Java.)~~ YIKES. It's almost a gigabyte now! Apparently upgrading `pds-github-util` needed an upgrade to `cryptography` which got **huge**.
+ MiB. ~~Let's try and keep it around there 😲 (Thanks, Java. And C++. But mostly Java.)~~ YIKES. ~~It's almost a gigabyte now! Apparently upgrading `pds-github-util` needed an upgrade to `cryptography` which got **huge**.~~ It's now 1.21 GB 😵.


### PR DESCRIPTION
## 📜 Summary

Merge this to resolve #1 by making the `Dockerfile` gets updated to:

- Install `openjdk11`
- Install `github_changelog_generator` 1.15.2 from the Gem repo instead of from a known git ref from source

⚠️ The Docker Hub has already been updated with this new image. We should probably have GitHub Actions do this instead 😅

## 🩺 Test Data and/or Report

Previously:
```console
$ docker container run --rm --interactive --tty --entrypoint /bin/sh nasapds/pds-github-actions-base:latest
/ # java -version 2>&1 | head -1
openjdk version "1.8.0_275"
/ # github_changelog_generator --version
Version: 1.15.2
```
With this PR:
```console
$ docker container run --rm --interactive --tty --entrypoint /bin/sh pds-github-actions-base:latest
/ # java -version 2>&1 | head -1
openjdk version "11.0.9" 2020-10-20
/ # github_changelog_generator --version
Version: 1.15.2
/ # echo but installed simply from the gem repo
but installed simply from the gem repo
```

## 🧩 Related Issues

- #1 
