### PR TITLE
Re Resolve #1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,14 @@ RUN : &&\
         sphinx==${sphinx} \
         twine==${twine} \
         &&\
-    gem install github_changelog_generator --version 1.15.2 &&\
+    cd /usr/src &&\
+    git clone https://github.com/github-changelog-generator/github-changelog-generator.git &&\
+    cd github-changelog-generator &&\
+    git checkout ${github_changelog_commit} &&\
+    gem build github_changelog_generator.gemspec &&\
+    gem install github_changelog_generator-1.15.2.gem --source https://rubygems.org &&\
+    cd .. &&\
+    rm -r github-changelog-generator &&\
     apk del /build &&\
     rm -rf /var/cache/apk/* &&\
     : /


### PR DESCRIPTION
## 📜 Summary

This re-resolves the re-opened #1 by going back to using commit 322e30a78115ab948e358cd916a9f78e55fe21c1 of [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator).

⚠️ Note: the image built from the pushed commit is already built and published to hub.docker.com and will be used on future GitHub Action runs.

## 🩺 Test Data and/or Report

```console
Cloning into 'github-changelog-generator'...
Note: switching to '322e30a78115ab948e358cd916a9f78e55fe21c1'.
…
  Successfully built RubyGem
  Name: github_changelog_generator
  Version: 1.15.2
  File: github_changelog_generator-1.15.2.gem
…
Successfully installed github_changelog_generator-1.15.2
32 gems installed
```

## 🧩 Related Issues

- #1 
