### PR TITLE
Resolve #10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV github_changelog_commit 322e30a78115ab948e358cd916a9f78e55fe21c1
 # ~~~~~~~~~~~~~~~~~~~
 
 ENV github3_py       1.3.0
-ENV pds_github_util  0.22.0
+ENV pds_github_util  0.22.2
 ENV requests         2.23.0
 ENV sphinx           3.2.1
 ENV sphinx_argparse  0.2.5


### PR DESCRIPTION
## 📜 Summary

Merge this if you dare to bump pds-github-util from 0.22.0 → 0.22.2 in the the GitHub Actions Base image, which'll resolve #10.

## 🩺 Test Data and/or Report

```console
$ docker image build --quiet --tag pds-github-actions-base:latest .
$ docker container run --rm --entrypoint /bin/ls pds-github-actions-base:latest -ld /usr/local/lib/python3.8/site-packages/pds_github_util-0.22.2.dist-info
drwxr-xr-x    2 root     root          4096 Aug 13 17:48 /usr/local/lib/python3.8/site-packages/pds_github_util-0.22.2.dist-info
$ echo \U+1F389
🎉
```

## 🧩 Related Issues

- Fixes #10 
