### PR TITLE
Trigger build when pds-github-util sends repository dispatch

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -17,7 +17,8 @@ on:
     push:
         tags:
             - 'v[0-9]+.[0-9]+.[0-9]+'
-
+    repository_dispatch:
+        types: [pds-github-util-built]
 
 # What to Do
 # ----------


### PR DESCRIPTION
**Summary**

Listen for a `pds-github-util-built` event from pds-github-util to
trigger a new build.

Resolve #14

**Related Issues**
NASA-PDS/pds-github-util#21
#10
