### PR TITLE
Resolve #20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN : &&\
     rm /tmp/m2-repository.tar.bz2 &&\
     apk update &&\
     apk add --no-progress --virtual /build openssl-dev libxml2-dev libxslt-dev libffi-dev ruby-dev make python3-dev cargo &&\
-    apk add --no-progress bash git-lfs gcc g++ musl-dev libxml2 libxslt git ruby ruby-etc ruby-json ruby-multi_json ruby-io-console ruby-bigdecimal openssh-client maven openjdk8 gnupg &&\
+    apk add --no-progress bash git-lfs gcc g++ musl-dev libxml2 libxslt git ruby ruby-etc ruby-json ruby-multi_json ruby-io-console ruby-bigdecimal openssh-client maven openjdk8 gnupg libgit2-dev &&\
     pip install --upgrade \
         pip setuptools wheel \
         pds-github-util \


### PR DESCRIPTION
## 🗒️ Summary

Merge this to resolve #20 by adding `libgit2-dev` to the GitHub Actions base image.

## ⚙️ Test Data and/or Report

Before updating the `Dockerfile`:
```console
$ docker container run --rm --entrypoint /sbin/apk nasapds/pds-github-actions-base info | egrep libgit2-dev
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.14/main: No such file or directory
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.14/community: No such file or directory
```
And after:
```console
$ docker container run --rm --entrypoint /sbin/apk pds-github-actions-base info | egrep libgit2-dev
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.14/main: No such file or directory
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.14/community: No such file or directory
libgit2-dev
$ echo \U+1F44F
👏
```

## ♻️ Related Issues

- #20 
- NASA-PDS/roundup-action#64
- NASA-PDS/pds-doi-service#247