### PR TITLE
Added sphinxcontrib-redoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,16 @@ FROM python:3.9.16-alpine3.16
 # Python Package Pins
 # ~~~~~~~~~~~~~~~~~~~
 
-ENV github3_py       1.3.0
-ENV lxml             4.6.3
-ENV numpy            1.21.2
-ENV pandas           1.3.4
-ENV requests         2.23.0
-ENV sphinx           3.2.1
-ENV sphinx_argparse  0.2.5
-ENV sphinx_rtd_theme 0.5.0
-ENV twine            3.4.2
-
+ENV github3_py          1.3.0
+ENV lxml                4.6.3
+ENV numpy               1.21.2
+ENV pandas              1.3.4
+ENV requests            2.23.0
+ENV sphinx              3.2.1
+ENV sphinx_argparse     0.2.5
+ENV sphinx_rtd_theme    0.5.0
+ENV sphinxcontrib_redoc 1.6.0
+ENV twine               3.4.2
 
 # Metadata
 # ~~~~~~~~
@@ -52,6 +52,7 @@ RUN : &&\
         sphinx==${sphinx} \
         sphinx-argparse==${sphinx_argparse} \
         sphinx-rtd-theme==${sphinx_rtd_theme} \
+        sphinxcontrib-redoc==${sphinxcontrib_redoc} \
         twine==${twine} \
         &&\
     gem install github_changelog_generator --version 1.16.4 &&\

--- a/README.md
+++ b/README.md
@@ -65,5 +65,6 @@ Substitute `:latest` with whatever's appropriate.
 - 😮 You'd think [GitHub Packages](https://github.com/features/packages) would be an alternative, but [GitHub Actions doesn't support using images from GitHub Packages](https://github.community/t/use-docker-image-from-github-packages-as-container/118709)!
 - 💀 There isn't even [anonymous pulls of images from GitHub Packages](https://github.community/t/make-it-possible-to-pull-docker-images-anonymously-from-github-package-registry/16677)!
 - 😑 Apparently engineers at GitHub are recommending to [migrate from GitHub Packages to the new GitHub Container Registry](https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images). The Container Registry is currently in public β.
-- 💽 It's currently ~~213~~ ~~216~~ ~~579~~ ~~593~~ ~~790~~ ~~815~~ ~~669~~ 931
- MiB. ~~Let's try and keep it around there 😲 (Thanks, Java. And C++. But mostly Java.)~~ YIKES. It's almost a gigabyte now!
+- 💽 It's currently ~~213~~ ~~216~~ ~~579~~ ~~593~~ ~~790~~ ~~815~~ ~~669~~ ~~931~~
+ MiB. ~~Let's try and keep it around there 😲 (Thanks, Java. And C++. But mostly Java.)~~ YIKES. It's 1.15 GiB now!
+ 


### PR DESCRIPTION
## 🗒️ Summary

Merge this to add `sphinxcontrib-redoc` to the GitHub Actions base image.

## ⚙️ Test Data and/or Report

"I have a truly marvelous demonstration of this proposition that this margin is too narrow to contain." —Pierre de Fermat.

## ♻️ Related Issues

- [roundup-action#109](https://github.com/NASA-PDS/roundup-action/issues/109)