### PR TITLE
Partial for pds-api#33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+*.sublime-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ENV sphinx_substitution_extensions 2020.5.27.0
 ENV sphinx_argparse                0.2.5
 ENV sphinx_rtd_theme               0.5.0
 ENV sphinxcontrib_redoc            1.6.0
+ENV sphinx_copybutton              0.5.2
 ENV twine                          3.4.2
 
 # Metadata
@@ -55,6 +56,7 @@ RUN : &&\
         sphinx-rtd-theme==${sphinx_rtd_theme} \
         sphinxcontrib-redoc==${sphinxcontrib_redoc} \
         sphinx-substitution-extensions==${sphinx_substitution_extensions} \
+        sphinx-copybutton==${sphinx_copybutton} \
         twine==${twine} \
         &&\
     gem install github_changelog_generator --version 1.16.4 &&\


### PR DESCRIPTION
## 🗒️ Summary

Merge this to get Sphinx docs building in pds-api. Note that [this PR](https://github.com/NASA-PDS/pds-api/pull/264) must also be merged and the new `:stable` tag for the `docker.io/nasapds/github-actions-base` image be created.

## ⚙️ Test Data and/or Report

https://github.com/nasa-pds-engineering-node/pds-api/actions/runs/4894679452

## ♻️ Related Issues

- [nasa-pds#33](https://github.com/NASA-PDS/github-actions-base/issues/33)