### PR TITLE
Node.js support in the base image (for Roundup Action)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .venv
 venv
 *.sublime-workspace
+# This is not a Node.js project, so ignore these
+package-lock.json
+package.json
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,13 @@ ENV sphinxcontrib_redoc            1.6.0
 ENV sphinx_copybutton              0.5.2
 ENV twine                          3.4.2
 
+
+# Node.js Package Pins
+# ~~~~~~~~~~~~~~~~~~~~
+
+ENV jest  29.7
+ENV jsdoc 4.0.2
+
 # Metadata
 # ~~~~~~~~
 
@@ -37,13 +44,14 @@ LABEL "maintainer"="Sean Kelly <kelly@seankelly.biz>"
 # Note we include some bigger Python packages used by other PDS projects.
 
 COPY m2-repository.tar.bz2 /tmp
+WORKDIR /root
 RUN : &&\
     mkdir /root/.m2 &&\
     tar x -C /root/.m2 -j -f /tmp/m2-repository.tar.bz2 &&\
     rm /tmp/m2-repository.tar.bz2 &&\
     apk update &&\
     apk add --no-progress --virtual /build ruby-dev make cargo &&\
-    apk add --no-progress bash git-lfs gcc g++ musl-dev libxml2 libxslt git ruby ruby-etc ruby-json ruby-multi_json ruby-io-console ruby-bigdecimal openssh-client maven openjdk8 gnupg libgit2-dev libffi-dev libxml2-dev libxslt-dev python3-dev openssl-dev &&\
+    apk add --no-progress bash git-lfs gcc g++ musl-dev libxml2 libxslt git ruby ruby-etc ruby-json ruby-multi_json ruby-io-console ruby-bigdecimal openssh-client maven openjdk8 gnupg libgit2-dev libffi-dev libxml2-dev libxslt-dev python3-dev openssl-dev npm &&\
     pip install --upgrade \
         pip setuptools wheel build \
         github3.py==${github3_py} \
@@ -60,6 +68,7 @@ RUN : &&\
         twine==${twine} \
         &&\
     gem install github_changelog_generator --version 1.16.4 &&\
+    npm install --save-dev jest@${jest} jsdoc@${jsdoc} &&\
     wget -qP /usr/local/bin https://github.com/X1011/git-directory-deploy/raw/master/deploy.sh &&\
     chmod +x /usr/local/bin/deploy.sh &&\
     apk del /build &&\

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Enter _this_ image. By deriving specific GitHub Actions from _this_ image, we ma
 
 Of course, this makes a few assumptions:
 
-- PDS GitHub actions will need Python 3.9.7.
-- They'll run on Alpine Linux 3.14.
+- PDS GitHub actions will need Python 3.9.16.
+- They'll run on Alpine Linux 3.16.
 - They'll have access to development tools:
   - GCC
   - MUSL C library
@@ -23,6 +23,7 @@ Of course, this makes a few assumptions:
   - Git
   - Ruby (yes, in addition to Python)
   - Java (yes, in addition to Ruby)
+  - Node.js (yes, in addition to Java)
 
 And we might expand on this in the future.
 


### PR DESCRIPTION
## 🗒️ Summary

Merge this so the base image (used by the Roundup Action) will have Node.js tools, specifically [jest](https://jestjs.io/) for teseting and [jsdoc](https://jsdoc.app) for documentation generation.

## ⚙️ Test Data and/or Report
```console
$ docker container run --rm --entrypoint /bin/sh nasapds/github-actions-base:latest -c 'ls -l /root/node_modules/.bin/jsdoc /root/node_modules/.bin/jest'
lrwxrwxrwx    1 root     root            19 Jan  5 20:46 /root/node_modules/.bin/jest -> ../jest/bin/jest.js
lrwxrwxrwx    1 root     root            17 Jan  5 20:46 /root/node_modules/.bin/jsdoc -> ../jsdoc/jsdoc.js
```

## ♻️ Related Issues

- https://github.com/NASA-PDS/devops/issues/68