### PR TITLE
Python 3.13 transition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,44 @@
 # 🌄 PDS Engineering: GitHub Actions Base
 # =======================================
 
-FROM python:3.9.16-alpine3.16
+FROM python:3.13.5-alpine3.22
 
 
-# Support
-# -------
+# Varaibles and Support
+# ---------------------
+#
+# Set up the various variables and the image metadata.
+#
 #
 # Python Package Pins
 # ~~~~~~~~~~~~~~~~~~~
+#
+# It would be nice to use Alpine's own package manager (`apk`) to install a
+# number of Python packages, however, despite the official python:3.13.5 image
+# being based on alpine3.22, alpine3.22 itself has standardized on python 3.12.
+# Therefore, we have to `pip install` all of our dependencies and avoid the
+# apk py3-* packages.
 
-ENV github3_py                     1.3.0
-ENV lxml                           4.6.3
-ENV numpy                          1.21.2
-ENV pandas                         1.3.4
-ENV requests                       2.23.0
-ENV sphinx                         3.0.4
-ENV sphinx_substitution_extensions 2020.5.27.0
-ENV sphinx_argparse                0.2.5
-ENV sphinx_rtd_theme               0.5.0
-ENV sphinxcontrib_redoc            1.6.0
-ENV sphinx_copybutton              0.5.2
-ENV twine                          3.4.2
+ENV github3_py=4.0.1
+ENV lxml=6.0.0
+ENV numpy=2.2.3
+ENV pandas=2.3.0
+ENV requests=2.32.4
+ENV sphinx_argparse=0.5.2
+ENV sphinx_copybutton=0.5.2
+ENV sphinx_rtd_theme=3.0.2
+ENV sphinx_substitution_extensions=2025.6.6
+ENV sphinx=8.2.3
+ENV sphinxcontrib_redoc=1.6.0
+ENV twine=6.1.0
 
 
 # Node.js Package Pins
 # ~~~~~~~~~~~~~~~~~~~~
 
-ENV jest  29.7
-ENV jsdoc 4.0.2
+ENV jest=29.7
+ENV jsdoc=4.0.2
+
 
 # Metadata
 # ~~~~~~~~
@@ -45,28 +55,40 @@ LABEL "maintainer"="Sean Kelly <kelly@seankelly.biz>"
 
 COPY m2-repository.tar.bz2 /tmp
 WORKDIR /root
+
+
+# Base packages from the package manager, `apk`
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 RUN : &&\
     mkdir /root/.m2 &&\
     tar x -C /root/.m2 -j -f /tmp/m2-repository.tar.bz2 &&\
     rm /tmp/m2-repository.tar.bz2 &&\
     apk update &&\
     apk add --no-progress --virtual /build ruby-dev make cargo &&\
-    apk add --no-progress bash git-lfs gcc g++ musl-dev libxml2 libxslt git ruby ruby-etc ruby-json ruby-multi_json ruby-io-console ruby-bigdecimal openssh-client maven openjdk8 gnupg libgit2-dev libffi-dev libxml2-dev libxslt-dev python3-dev openssl-dev npm &&\
-    pip install --upgrade \
-        pip setuptools wheel build \
-        github3.py==${github3_py} \
-        lxml==${lxml} \
-        numpy==${numpy} \
-        pandas==${pandas} \
-        requests==${requests} \
-        sphinx==${sphinx} \
-        sphinx-argparse==${sphinx_argparse} \
-        sphinx-rtd-theme==${sphinx_rtd_theme} \
-        sphinxcontrib-redoc==${sphinxcontrib_redoc} \
-        sphinx-substitution-extensions==${sphinx_substitution_extensions} \
-        sphinx-copybutton==${sphinx_copybutton} \
-        twine==${twine} \
-        &&\
+    apk add --no-progress bash git-lfs gcc g++ musl-dev libxml2 libxslt git ruby ruby-libs ruby-multi_json &&\
+    apk add --no-progress openssh-client maven openjdk8 gnupg libgit2-dev libffi-dev libxml2-dev libxslt-dev &&\
+    apk add --no-progress openssl-dev npm &&\
+    :
+
+
+# Python packages from `pip`
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RUN : &&\
+    pip install --quiet --upgrade pip setuptools wheel build &&\
+    pip install --quiet github3.py==${github3_py} lxml==${lxml} numpy==${numpy} pandas==${pandas} &&\
+    pip install --quiet requests==${requests} sphinx_argparse==${sphinx_argparse} &&\
+    pip install --quiet sphinx_copybutton==${sphinx_copybutton} sphinx_rtd_theme==${sphinx_rtd_theme} &&\
+    pip install --quiet sphinx_substitution_extensions==${sphinx_substitution_extensions} sphinx==${sphinx} &&\
+    pip install --quiet sphinxcontrib_redoc==${sphinxcontrib_redoc} twine==${twine} &&\
+    :
+
+
+# Node.js packages from `npm`
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RUN : &&\
     gem install github_changelog_generator --version 1.16.4 &&\
     npm install --save-dev jest@${jest} jsdoc@${jsdoc} &&\
     wget -qP /usr/local/bin https://github.com/X1011/git-directory-deploy/raw/master/deploy.sh &&\

--- a/README.md
+++ b/README.md
@@ -51,13 +51,11 @@ To make a release of this image on the [Docker Hub](https://hub.docker.com/), do
 But if you ever need to do that by hand, try this:
 
 ```console
-docker image build --tag github-actions-base:latest .
-docker image tag github-actions-base:latest nasapds/github-actions-base:latest
-docker login
-docker image push nasapds/github-actions-base:latest
+docker login --username nasapds
+docker buildx build --tag nasapds/github-actions-base:TAGNAME --platform linux/amd64,linux/arm64 --push .
 ```
 
-Substitute `:latest` with whatever's appropriate.
+Substitute `:TAGNAME` with whatever's appropriate.
 
 
 ## ⏰ Future Work


### PR DESCRIPTION
## 🗒️ Summary

Upgrades the base image to Alpine 3.22 + Python 3.13 + dependencies of the various Python packages that also require Python 3.13.

Used by the Roundup Action.

## ⚙️ Test Data and/or Report

See successful runs on the 3.13 Roundup on the two example packages:

- https://github.com/nasa-pds-engineering-node/epitome/actions/runs/16601184002
- https://github.com/nasa-pds-engineering-node/exemplar/actions/runs/16578516131


## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/105