### PR TITLE
Resolve Python documentation generation issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,6 @@ ENV lxml=6.0.0
 ENV numpy=2.2.3
 ENV pandas=2.3.0
 ENV requests=2.32.4
-ENV sphinx_argparse=0.5.2
-ENV sphinx_copybutton=0.5.2
-ENV sphinx_rtd_theme=3.0.2
-ENV sphinx_substitution_extensions=2025.6.6
-ENV sphinx=8.2.3
-ENV sphinxcontrib_redoc=1.6.0
 ENV twine=6.1.0
 
 
@@ -78,10 +72,7 @@ RUN : &&\
 RUN : &&\
     pip install --quiet --upgrade pip setuptools wheel build &&\
     pip install --quiet github3.py==${github3_py} lxml==${lxml} numpy==${numpy} pandas==${pandas} &&\
-    pip install --quiet requests==${requests} sphinx_argparse==${sphinx_argparse} &&\
-    pip install --quiet sphinx_copybutton==${sphinx_copybutton} sphinx_rtd_theme==${sphinx_rtd_theme} &&\
-    pip install --quiet sphinx_substitution_extensions==${sphinx_substitution_extensions} sphinx==${sphinx} &&\
-    pip install --quiet sphinxcontrib_redoc==${sphinxcontrib_redoc} twine==${twine} &&\
+    pip install --quiet requests==${requests} twine==${twine} &&\
     :
 
 

--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ Substitute `:TAGNAME` with whatever's appropriate.
 - 💀 There isn't even [anonymous pulls of images from GitHub Packages](https://github.community/t/make-it-possible-to-pull-docker-images-anonymously-from-github-package-registry/16677)!
 - 😑 Apparently engineers at GitHub are recommending to [migrate from GitHub Packages to the new GitHub Container Registry](https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images). The Container Registry is currently in public β.
 - 💽 It's currently ~~213~~ ~~216~~ ~~579~~ ~~593~~ ~~790~~ ~~815~~ ~~669~~ ~~931~~
- MiB. ~~Let's try and keep it around there 😲 (Thanks, Java. And C++. But mostly Java.)~~ YIKES. It's 1.15 GiB now!
+ MiB. ~~Let's try and keep it around there 😲 (Thanks, Java. And C++. But mostly Java.)~~ YIKES. It's ~~1.15~~ 1.57 GiB now!
  


### PR DESCRIPTION
## 🗒️ Summary

Merge this to remove Sphinx completely from the base image used by the Roundup Action.

This is in partial support of https://github.com/NASA-PDS/roundup-action/issues/157

This requires a [merge to a pull request of the Roundup Action as well](https://github.com/NASA-PDS/roundup-action/pull/158).

## ⚙️ Test Data and/or Report

See [a successfully published set of Python docs using this base image](https://nasa-pds-engineering-node.github.io/epitome/) and its [corresponding Actions run](https://github.com/nasa-pds-engineering-node/epitome/actions/runs/18446130018).

## ♻️ Related Issues

- https://github.com/NASA-PDS/roundup-action/issues/157
